### PR TITLE
Provide default slideshow bundle

### DIFF
--- a/config/install/field.field.media.slideshow.slideshow_items.yml
+++ b/config/install/field.field.media.slideshow.slideshow_items.yml
@@ -1,0 +1,26 @@
+langcode: und
+status: true
+dependencies:
+  config:
+    - field.storage.media.slideshow_items
+    - media_entity.bundle.slideshow
+id: media.slideshow.slideshow_items
+field_name: slideshow_items
+entity_type: media
+bundle: slideshow
+label: 'Slideshow items'
+description: 'Media items that belong to this slideshow.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+      instagram: instagram
+      tweet: tweet
+    sort:
+      field: _none
+field_type: entity_reference

--- a/config/install/field.storage.media.slideshow_items.yml
+++ b/config/install/field.storage.media.slideshow_items.yml
@@ -1,0 +1,20 @@
+langcode: und
+status: true
+dependencies:
+  module:
+    - entity_reference
+    - media_entity
+id: media.slideshow_items
+field_name: slideshow_items
+entity_type: media
+type: entity_reference
+settings:
+  target_type: media
+module: entity_reference
+locked: false
+cardinality: -1
+translatable: true
+indexes:
+  target_id:
+    - target_id
+persist_with_no_fields: false

--- a/config/install/media_entity.bundle.slideshow.yml
+++ b/config/install/media_entity.bundle.slideshow.yml
@@ -1,0 +1,12 @@
+langcode: und
+status: true
+dependencies:
+  module:
+    - media_entity_slideshow
+id: slideshow
+label: Slideshow
+description: 'Slideshows of media items.'
+type: slideshow
+type_configuration:
+  source_field: slideshow_items
+field_map: {  }


### PR DESCRIPTION
This module should provide the bare minimum for the slideshow bundle, which can then be extended by Media Pinkeye. So that's what this PR does -- pulls the slideshow bundle (and slideshow_items field) out of Pinkeye.
